### PR TITLE
improved docker build times if you have caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-MAINTAINER NGINX Docker Maintainers "docker-maint@nginx.com"
+MAINTAINER OpenTargets ops team "ops@opentargets.org"
 
 ENV NGINX_VERSION 1.9.6-1~jessie
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,23 @@ FROM debian:jessie
 
 MAINTAINER NGINX Docker Maintainers "docker-maint@nginx.com"
 
-RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
-RUN echo "deb http://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/apt/sources.list
-
 ENV NGINX_VERSION 1.9.6-1~jessie
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates nginx=${NGINX_VERSION} openssh-server gettext-base curl && \
-    curl --silent --location https://deb.nodesource.com/setup_0.12 | bash - && \
-    apt-get install --yes nodejs git tar bzip2 && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62 \
+    && echo "deb http://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+        ca-certificates \
+        nginx=${NGINX_VERSION} \
+        openssh-server \
+        gettext-base \
+        curl \
+        git \
+        tar \
+        bzip2 \
+    && curl --silent --location https://deb.nodesource.com/setup_0.12 | bash - \
+    && apt-get install --no-install-recommends --no-install-suggests -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
@@ -20,13 +27,30 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
 # Create directories
 RUN mkdir -p /var/www/app /usr/share/nginx_auth /usr/share/nginx_crt /opt/share/webapp
 
-#copy code and install node & bower deps
+# Trying to exploit docker container layers:
+# If the package.json file changes then Docker will re-run the npm install sequence...
+# otherwise our modules are cached so we aren't rebuilding them every time we change our apps source code!
+COPY package.json /tmp/package.json
+# there are some dependencies not in npm library yet
+COPY components/ /tmp/components
+RUN cd /tmp \
+    && echo 'unsafe-perm = true' > .npmrc \
+    && echo 'progress=false' >> .npmrc \
+    && npm install \
+    && mkdir -p /opt/share/webapp \
+    && cp -a /tmp/node_modules /opt/share/webapp/
+
+# From here we load our application's code in, therefore the previous docker
+# "layer" thats been cached will be used if possible
+WORKDIR /opt/share/webapp
+
+#copy code and run postinstall script & bower deps
 COPY . /opt/share/webapp/
-RUN cd /opt/share/webapp && \
-    echo 'unsafe-perm = true' > .npmrc && \
-    npm install && \
-    cp -r ./app /var/www && \
-    rm -rf /opt/share/webapp 
+RUN /opt/share/webapp/node_modules/.bin/bower install --allow-root \
+    && /opt/share/webapp/node_modules/.bin/jspm install \
+    && /opt/share/webapp/node_modules/.bin/gulp build-all \
+    && cp -r ./app /var/www \
+    && rm -rf /opt/share/webapp
 
 COPY ./nginx_conf/server.* /usr/share/nginx_crt/
 COPY ./nginx_conf/nginx.conf /etc/nginx/nginx.conf

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2016 Biogen, GlaxoSmithKline, EMBL - European Bioinformatics Institute, Wellcome Trust Sanger Institute
+
+This software was developed as part of the Open Targets project. For more information please see:
+
+http://www.opentargets.org
+Target Validation platform
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,19 @@ export ENSEMBL_API_KEY=${ENSEMBL_API_KEY:=YOUR_KEY_HERE}
 envsubst < /etc/nginx/conf.d/app_server.template > /etc/nginx/conf.d/app_server.conf
 envsubst '$REST_API_SCHEME:$ENSEMBL_API_KEY' < /etc/nginx/conf.d/rest_api_scheme.template > /etc/nginx/conf.d/rest_api_scheme.conf
 
+echo "======================================="
+echo "TESTING CONNECTION TO REST API ..."
+echo ""
+
+curl -kv --max-time 30 --connect-timeout 10 ${REST_API_SCHEME}://${REST_API_SERVER}/public/utils/ping
+
+echo "======================================="
+echo "Checking REST API version ..."
+echo ""
+
+curl -kv --max-time 30 --connect-timeout 10 ${REST_API_SCHEME}://${REST_API_SERVER}/public/utils/version
+
+
 # As argument is not related to elasticsearch,
 # then assume that user wants to run his own process,
 # for example a `bash` shell to explore this image

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "0.5.1"
   },
   "scripts": {
-    "postinstall": "bower install --allow-root && ./node_modules/.bin/jspm install && gulp build-all",
+    "setup": "./node_modules/.bin/bower install --allow-root && ./node_modules/.bin/jspm install && ./node_modules/.bin/gulp build-all",
     "start": "cd server && node server.js",
     "test": "gulp test",
     "test-single-run": "karma start tests/unit/karma.conf.js  --single-run"

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,7 +1,3 @@
-language: node_js
-node_js:
-  - "0.12"
-
 build:
   cache: true
   post_ci:

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,6 +1,9 @@
+language: node_js
+node_js:
+  - "0.12"
+
 build:
-  ci:
-    - echo 'CI is running.. wish i knew what to test'
+  cache: true
   post_ci:
       - docker build -t="opentargets/webapp:$BRANCH.$BUILD_NUMBER" .
 
@@ -11,19 +14,6 @@ build:
       # GCR.io
       - docker tag opentargets/webapp:$BRANCH.$BUILD_NUMBER eu.gcr.io/open-targets/webapp:$BRANCH.$BUILD_NUMBER
       - docker push eu.gcr.io/open-targets/webapp:$BRANCH.$BUILD_NUMBER
-
-integrations:
-  # deploy:
-  #   # Public Image (docker)
-  #   - integrationName: "GKE-opentargets"
-  #     type: gke
-  #     target: GKE-opentargets
-  #     application_name: "webapp"
-  #     env_name: "cluster-dev"
-  #     image_name: "opentargets/webapp"
-  #     image_tag: "$BRANCH.$BUILD_NUMBER"
-  #
-
 
   hub:
     - integrationName: hub_docker

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,5 +1,7 @@
 build:
   cache: true
+  ci:
+    - echo 'some test should go here..'
   post_ci:
       - docker build -t="opentargets/webapp:$BRANCH.$BUILD_NUMBER" .
 


### PR DESCRIPTION
i moved the commands in the dockerfile around so that we can take advantage of the docker cache. 
There is also some additional logging when the container starts. 

I found out that the previous docker container layers can be reused when building again leading to large speedups. 
I changed the dockerfile such that if you don't change your `package.json` between builds, it reuses the layers it already built. That is as long as the building happens on the same machine. Shippable for eg. has a caching mechanism to make this happen. Not sure about quay.io yet.

*important* For the caching to works I had to rename the `post-install` script to `setup` in package.json. 
I moved the same commands later in the dockerfile.