### PR TITLE
working with current live.json config file

### DIFF
--- a/app/config/live.json
+++ b/app/config/live.json
@@ -1,0 +1,6 @@
+{
+    "apiVersion": "1.2.1",
+    "features": {
+        "filterByTargetList": true
+    }
+}

--- a/app/js/api-service.js
+++ b/app/js/api-service.js
@@ -11,7 +11,7 @@ angular.module('cttvServices')
 /**
 * The API services, with methods to call the ElasticSearch API
 */
-    .factory('cttvAPIservice', ['$http', '$log', '$location', '$rootScope', '$q', '$timeout', function($http, $log, $location, $rootScope, $q, $timeout) {
+    .factory('cttvAPIservice', ['$http', '$log', '$location', '$rootScope', '$q', '$timeout', 'liveConfig', function($http, $log, $location, $rootScope, $q, $timeout, liveConfig) {
         'use strict';
 
 
@@ -103,7 +103,12 @@ angular.module('cttvServices')
             return 200 <= status && status < 300;
         }
 
-
+        // Set the version of the rest api if it is set in the live config file
+        liveConfig.then (function (config) {
+            if (config.apiVersion) {
+                api.version(config.apiVersion);
+            }
+        });
 
         /*
         * Private function to actually call the API
@@ -121,17 +126,20 @@ angular.module('cttvServices')
 
             var deferred = $q.defer();
             var promise = deferred.promise;
-            var url = api.url[queryObject.operation](params);
-            console.warn("URL : " + url);
 
             countRequest( params.trackCall===false ? undefined : true );
 
             // Params for api.call are: url, data (for POST) and return format
-            var resp = api.call(url, (queryObject.method=="POST" ? params : undefined), (params.format || "json"))
-                .then (done)
-                .catch(function (err) {
-                    cttvAPI.defaultErrorHandler (err, params.trackCall);
-                });
+
+            liveConfig.then (function (config) {
+                var url = api.url[queryObject.operation](params);
+                console.warn("URL : " + url);
+                api.call(url, (queryObject.method=="POST" ? params : undefined), (params.format || "json"))
+                    .then (done)
+                    .catch(function (err) {
+                        cttvAPI.defaultErrorHandler (err, params.trackCall);
+                    });
+            });
 
             return promise;
             //return resp.then(handleSuccess, handleError);

--- a/app/js/services.js
+++ b/app/js/services.js
@@ -5,6 +5,14 @@
 angular.module('cttvServices', []).
 
 
+    factory ('liveConfig', ['$log', '$http', function ($log, $http) {
+        'use strict';
+        return $http.get('/config/live.json')
+            .then (function (resp) {
+                return resp.data;
+            });
+    }]).
+
     /**
      * Some utility services.
      */
@@ -313,6 +321,3 @@ angular.module('cttvServices', []).
 
         return modalService;
     }])
-
-
-


### PR DESCRIPTION
We need a way to enable webapp config parameters being read live at load time. Two use cases:

1.- We want to test the webapp with a different rest api version than the one hardcoded. In a kubernetes cluster we can mount live a different version of the api via the config file

2.- We want to enable and disable features in the master branch so we don't need to wait for a fully working/complete feature to be merged into master
