### PR TITLE
fix the code testing for rest-api presence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ app/docs/*.html
 npm-debug.log
 app/outreach.json
 app/notifications.json
+.wercker

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,6 @@ VOLUME ["/var/cache/nginx"]
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-EXPOSE 80 443
+EXPOSE 80 443 8090
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,9 @@
+FROM: nginx-alpine
+
+COPY ./app /var/www/
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 80 443
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,15 +11,16 @@ envsubst '$REST_API_SCHEME:$ENSEMBL_API_KEY' < /etc/nginx/conf.d/rest_api_scheme
 
 echo "======================================="
 echo "TESTING CONNECTION TO REST API ..."
+echo at ${REST_API_SCHEME}://${REST_API_SERVER}
 echo ""
 
-curl -kv --max-time 30 --connect-timeout 10 ${REST_API_SCHEME}://${REST_API_SERVER}/public/utils/ping
+curl -k --max-time 30 --connect-timeout 10 ${REST_API_SCHEME}://${REST_API_SERVER}/api/latest/public/utils/ping
 
 echo "======================================="
 echo "Checking REST API version ..."
 echo ""
 
-curl -kv --max-time 30 --connect-timeout 10 ${REST_API_SCHEME}://${REST_API_SERVER}/public/utils/version
+curl -k --max-time 30 --connect-timeout 10 ${REST_API_SCHEME}://${REST_API_SERVER}/api/latest/public/utils/version
 
 
 # As argument is not related to elasticsearch,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -e
 
 export REST_API_SCHEME=${REST_API_SCHEME:=https}
 export REST_API_SERVER=${REST_API_SERVER:=www.targetvalidation.org:443}

--- a/k8-webapp-deployment.yml.template
+++ b/k8-webapp-deployment.yml.template
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: webapp-master
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: webapp
+        release: "master"
+    spec:
+      volumes:
+      - name: cert-volume
+        secret:
+          secretName: ssl-proxy-secret
+      containers:
+      - name: webapp
+        image: "quay.io/cttv/webapp:master"
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 443
+        - containerPort: 80
+        volumeMounts:
+        - mountPath: /usr/share/nginx_crt
+          name: cert-volume
+        env:
+        - name: REST_API_SCHEME
+          value: "http"
+        - name: REST_API_SERVER
+          value: "api-beta:8008"

--- a/k8-webapp-svc.yml.template
+++ b/k8-webapp-svc.yml.template
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webapp-beta
+  labels:
+    app: webapp
+    branch: "master"
+    commit: ${WERCKER_GIT_COMMIT}
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    protocol: TCP
+    name: http
+  - port: 443
+    protocol: TCP
+    name: https
+  selector:
+    app: webapp
+    branch: "master"
+    commit: ${WERCKER_GIT_COMMIT}

--- a/nginx_conf/nginx.conf
+++ b/nginx_conf/nginx.conf
@@ -52,8 +52,20 @@ http {
     include /etc/nginx/conf.d/app_server.conf;
 
     server {
+        listen 8090;
+        location /healthz
+          access_log off;
+          return 200 'working!';
+          add_header Content-Type text/plain;
+          }
+    }
+
+    server {
         listen 80 default_server;
         listen 443 ssl http2 default_server;
+
+        root /var/www/app/;
+
         ssl_certificate /usr/share/nginx_crt/server.crt;
         ssl_certificate_key /usr/share/nginx_crt/server.key;
 
@@ -80,10 +92,6 @@ http {
     	}
 
 
-      location /healthz {
-    return 200 'working!';
-    add_header Content-Type text/plain;
-}
 
         # Proxying connections to application servers
         location /api {
@@ -106,7 +114,6 @@ http {
     #handle maintenance status
     error_page 503 @maintenance;
     location @maintenance {
-        root /var/www/app/;
         rewrite ^(.*)$ /error503.html break;
     }
 
@@ -215,7 +222,6 @@ http {
      }
 
      location ~* /(js|css|vendor|build)/.*\.(js|css|png|jpg|jpeg|gif|ico)$ {
-        root /var/www/app/;
         if (-f $document_root/maintenance.on) {
                 return 503;
             }
@@ -224,7 +230,6 @@ http {
     }
 
     location / {
-        root /var/www/app/;
         if (-f $document_root/maintenance.on) {
                     return 503;
                }

--- a/nginx_conf/nginx.conf
+++ b/nginx_conf/nginx.conf
@@ -53,7 +53,7 @@ http {
 
     server {
         listen 8090;
-        location /healthz
+        location /healthz {
           access_log off;
           return 200 'working!';
           add_header Content-Type text/plain;

--- a/nginx_conf/nginx.conf
+++ b/nginx_conf/nginx.conf
@@ -80,6 +80,11 @@ http {
     	}
 
 
+      location /healthz {
+    return 200 'working!';
+    add_header Content-Type text/plain;
+}
+
         # Proxying connections to application servers
         location /api {
 

--- a/nginx_conf/nginx.conf
+++ b/nginx_conf/nginx.conf
@@ -53,7 +53,7 @@ http {
 
     server {
         listen 8090;
-        location /healthz {
+        location /heartbeat {
           access_log off;
           return 200 'working!';
           add_header Content-Type text/plain;

--- a/nginx_conf/nginx.conf
+++ b/nginx_conf/nginx.conf
@@ -42,8 +42,8 @@ http {
 
     proxy_cache_path /var/cache/nginx/cache_proxy levels=1 keys_zone=appproxy:10m inactive=1d max_size=1g;
 
-    resolver 192.168.0.10 192.168.0.11 192.168.0.12 8.8.8.8 valid=300s;
-    resolver_timeout 10s;
+    # resolver 192.168.0.10 192.168.0.11 192.168.0.12 8.8.8.8 valid=300s;
+    # resolver_timeout 10s;
 
 
     large_client_header_buffers 4 32k;
@@ -69,8 +69,8 @@ http {
         ssl_ciphers DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:kEDH+AESGCM:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
         ssl_session_cache shared:SSL:10m;
-        resolver 192.168.0.10 192.168.0.11 192.168.0.12  valid=300s;
-        resolver_timeout 10s;
+        # resolver 192.168.0.10 192.168.0.11 192.168.0.12  valid=300s;
+        # resolver_timeout 10s;
         # just enable this if you are really happy with going trough https only
         #  add_header Strict-Transport-Security max-age=86400;
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,25 @@
+box: node
+dev:
+  steps:
+    - npm-install
+    - internal/watch:
+      code: npm start
+      reload: true
+build:
+  steps:
+    - npm install
+    - npm run setup
+    # - internal/docker-push:
+    #   entrypoint: docker-entrypoint.sh
+    #   tag: latest $WERCKER_GIT_COMMIT, $WERCKER_GIT_BRANCH
+    #   registry: https://registry.hub.docker.com
+    #   repository: opentargets/webapp
+    #   username: $OT_DOCKER_HUB_USERNAME
+    #   password: $OT_DOCKER_HUB_PASSWORD
+    # - scripts: |
+    #   docker build Dockerfile.build -t "opentargets/webapp:prod-$WERCKER_GIT_COMMIT" .
+    #   docker push opentargets/webapp
+
+# deploy-to-gke:
+#   steps:
+#     -


### PR DESCRIPTION
this fixes a bug i had left behind. 
Now when spinning for the first time the container checks if the rest-api is reachable. 

I would also like to implement a HTTP (not HTTPS!) ping from the `nginx.conf` of the webapp. At the moment you are rewriting all the traffic to HTTPS though. Not really sure how to open HTTP for one endpoint. 
Any suggestions from the nginx experts? @apierleoni @emepyc 